### PR TITLE
Use newline for the end of log line

### DIFF
--- a/logformat.go
+++ b/logformat.go
@@ -82,7 +82,7 @@ func (al *ApacheLog) LogLine(
 	reqtime time.Duration,
 ) {
 	al.logger.Write(al.Format(r, status, respHeader, reqtime))
-	al.logger.Write([]byte{12})
+	al.logger.Write([]byte{10})
 }
 
 func defaultAppend(start *int, i *int, b *bytes.Buffer, str string) {

--- a/logformat.go
+++ b/logformat.go
@@ -82,7 +82,7 @@ func (al *ApacheLog) LogLine(
 	reqtime time.Duration,
 ) {
 	al.logger.Write(al.Format(r, status, respHeader, reqtime))
-	al.logger.Write([]byte{10})
+	al.logger.Write([]byte{'\n'})
 }
 
 func defaultAppend(start *int, i *int, b *bytes.Buffer, str string) {


### PR DESCRIPTION
`byte{12}` at the end of log line is a typo of `byte{10}`?

https://github.com/lestrrat/go-apache-logformat/commit/26b69b0eada7d8e66d3b613d060b8948071b4899#diff-3a497b708301db4a2d3a3f665ae5ce8bL84
