### PR TITLE
Fix percent t

### DIFF
--- a/format.go
+++ b/format.go
@@ -99,8 +99,9 @@ func timeFormatter(key string) (FormatWriter, error) {
 		} else if strings.HasPrefix(key, endPrefix) {
 			return makeRequestTimeEnd(key[len(endPrefix):])
 		}
-
-		return nil, errors.Wrap(ErrUnimplemented, "failed to compile format")
+		// if specify the format of strftime(3) without begin: or end:, same as bigin:
+		// FYI https://httpd.apache.org/docs/current/en/mod/mod_log_config.html
+		return makeRequestTimeBegin(key)
 	}
 	return formatter, nil
 }

--- a/logformat_test.go
+++ b/logformat_test.go
@@ -135,17 +135,19 @@ func TestTime(t *testing.T) {
 	// Mental note: %{[mu]?sec}t should (milli|micro)?seconds since the epoch.
 	testLog(t,
 		fmt.Sprintf(
-			`%%T %%D %%{sec}t %%{msec}t %%{usec}t %%{begin:%s}t %%{end:%s}t`,
+			`%%T %%D %%{sec}t %%{msec}t %%{usec}t %%{begin:%s}t %%{end:%s}t %%{%s}t`,
+			pattern,
 			pattern,
 			pattern,
 		),
 		fmt.Sprintf(
-			"1 1000000 %d %d %d %s %s\n",
+			"1 1000000 %d %d %d %s %s %s\n",
 			longTimeAgo/time.Second,
 			longTimeAgo/time.Millisecond,
 			longTimeAgo/time.Microsecond,
 			f.FormatString(cl.Now()),
 			f.FormatString(cl.Now().Add(time.Second)),
+			f.FormatString(cl.Now()),
 		),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cl.Add(time.Second)


### PR DESCRIPTION
handling strftime(3) without `begin:` or `end:`

if without `begin:` or `end:` , same as `begin:` by default
```
settings
LogFormat "time:%{%Y-%m-%dT%H:%M:%S%z}t begin_time:%{begin:%Y-%m-%dT%H:%M:%S%z}t end_time:%{end:%Y-%m-%dT%H:%M:%S%z}t" common

log output
time:2017-06-27T10:53:54+0000 begin_time:2017-06-27T10:53:54+0000 end_time:2017-06-27T10:53:59+0000
```
FYI: https://httpd.apache.org/docs/current/en/mod/mod_log_config.html